### PR TITLE
Update HACKING.rst

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -8,9 +8,6 @@ fork.  If you do not understand what this means or this process seems
 overly complicated feel free to ask questions on the # channel
 or in the @yahoo-inc.com mailing list.
 
-Prior to submitting a pull request, please complete a
-<a href="https://yahoocla.herokuapp.com/">Yahoo CLA agreement</a>.
-
 General
 -------
 Running and testing code requires installing serviceping.  It


### PR DESCRIPTION
The CLA is no longer required and the app is not maintained.  Removed the link from the documentation.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
